### PR TITLE
💎 Add support for repos without a Gemfile.lock

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,6 @@ branding:
   color: orange
 inputs:
   conclusionLevel:
-    description: "Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)"
+    description: Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)
     required: false
     default: "neutral"

--- a/action/install-gems.sh
+++ b/action/install-gems.sh
@@ -1,5 +1,0 @@
-cat Gemfile.lock | \
-    grep "\srubocop.* ([[:digit:]]" | \
-    sed 's/\([a-z\-]\+\) (\(.*\))/\1:\2/' | \
-    xargs | \
-    xargs gem install -N

--- a/action/install_gems.rb
+++ b/action/install_gems.rb
@@ -1,0 +1,65 @@
+class GemfileStrategy
+  def install
+    system("gem install -N #{gem_specifications.join(' ')}")
+  end
+
+  private
+
+  def gem_specifications
+    File
+      .read("Gemfile.lock")
+      .lines
+      .select { |l| line_contains_gem_we_care_about?(l) }
+      .select { |l| line_contains_exact_version?(l) }
+      .map { |l| gemfile_line_to_cli_specification(l) }
+  end
+
+  def gemfile_line_to_cli_specification(line)
+    name, version = line.split(' ')
+    version = version.tr('()', '')
+    %("#{name}:#{version}")
+  end
+
+  def line_contains_gem_we_care_about?(line)
+    line.include?('rubocop')
+  end
+
+  def line_contains_exact_version?(line)
+    line.match(/\(\d*\.\d*\.\d*\)/)
+  end
+end
+
+class GemspecStrategy
+  attr_reader :gemspec
+
+  def initialize(filename)
+    @gemspec = Gem::Specification.load(filename)
+  end
+
+  def install
+    gemspec
+      .dependencies
+      .select { |d| gem_we_care_about?(d.name) }
+      .each { |d| Gem.install(d.name, d.requirement) }
+  end
+
+  private
+
+  def gem_we_care_about?(name)
+    return true if name == 'standard'
+
+    name.start_with?('rubocop')
+  end
+end
+
+def choose_gem_strategy
+  if File.exist?('Gemfile.lock')
+    GemfileStrategy.new
+  elsif gemspec_file = Dir.glob('*.gemspec').first
+    GemspecStrategy.new(gemspec_file)
+  else
+    raise "Assumed a Gemfile.lock or a .gemspec file existed... but it doesn't!"
+  end
+end
+
+choose_gem_strategy.install

--- a/action/install_gems.rb
+++ b/action/install_gems.rb
@@ -7,7 +7,7 @@ class GemfileStrategy
 
   def gem_specifications
     File
-      .read("Gemfile.lock")
+      .read('Gemfile.lock')
       .lines
       .select { |l| line_contains_gem_we_care_about?(l) }
       .select { |l| line_contains_exact_version?(l) }
@@ -21,7 +21,8 @@ class GemfileStrategy
   end
 
   def line_contains_gem_we_care_about?(line)
-    line.include?('rubocop')
+    name = line.strip.split(' ').first
+    gem_we_care_about?(name)
   end
 
   def line_contains_exact_version?(line)
@@ -42,14 +43,10 @@ class GemspecStrategy
       .select { |d| gem_we_care_about?(d.name) }
       .each { |d| Gem.install(d.name, d.requirement) }
   end
+end
 
-  private
-
-  def gem_we_care_about?(name)
-    return true if name == 'standard'
-
-    name.start_with?('rubocop')
-  end
+def gem_we_care_about?(name)
+  name == 'standard' || name&.start_with?('rubocop')
 end
 
 def choose_gem_strategy

--- a/main.js
+++ b/main.js
@@ -1,9 +1,8 @@
 const exec = require("@actions/exec")
 
 async function run() {
-  await exec.exec('sh -l', [`${__dirname}/action/install-gems.sh`])
+  await exec.exec('ruby', [`${__dirname}/action/install_gems.rb`])
   await exec.exec('ruby', [`${__dirname}/action/action.rb`])
 }
-
 
 run()


### PR DESCRIPTION
We want to run `balto-rubocop` on a gem. It is best practice for gems to not commit `Gemfile.lock`. So we want to fallback to a `project.gemspec` file if it exists.

A `Gemfile.lock` has the benefit of having absolute versions determined.  This allows us to generate a command of the form...

```bash 
gem install -N "rubocop:0.77.0" "rubocop-performance:1.5.2"
```

...installing multiple gems at once.

When working with a `gemspec` file, we don't have absolute versions. We might have a version with multiple requirements that are not yet resolved, something like...

```ruby
gemspec.add_development_dependency "rubocop", "~> 0.50.0", "<= 60"
```

There's no way (that I could find) to represent multiple requirements, and install multiple gems in one invocation from the command line. So for the `gemspec` strategy, we install dependencies one at a time.

Also expanded the installable gems to include `standard`, as it's being used by one of our projects.