### PR TITLE
use --force-exclusion flag when calling Rubocop

### DIFF
--- a/action/action.rb
+++ b/action/action.rb
@@ -29,7 +29,7 @@ end
 compare_sha = event.pull_request.base.sha
 
 Dir.chdir(ENV["GITHUB_WORKSPACE"])
-rubocop_json = `git diff --name-only #{compare_sha} --diff-filter AM | xargs rubocop --format json`
+rubocop_json = `git diff --name-only #{compare_sha} --diff-filter AM | xargs rubocop --force-exclusion --format json`
 
 # print json
 


### PR DESCRIPTION
When supplying directories or files to Rubocop as command-line
arguments, by default, it does not apply any file exclusion rules
configured via `Exclude` in `.rubocop.yml`. As a result, Balto is
adding annotations for files that we've chosen to ignore (migrations,
`schema.rb`, etc...).

Using the `--force-exclusion` flag will respect any configured
exclusions, _even_ if matching files are explicitly passed in.

Example:
```yaml
AllCops:
  Exclude:
    - "db/**/*"
```

```shell
$ rubocop db/schema.rb
# inspects db/schema.rb
 
$ rubocop --force-exclusion db/schema.rb
Inspecting 0 files

0 files inspected, no offenses detected
```