### PR TITLE
Setup local testing

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+# Because we need node _and_ ruby, we have to use the larger docker image here
+-P ubuntu-latest=nektos/act-environments-ubuntu:18.04

--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ jobs:
 | Name | Description | Required | Default |
 |:-:|:-:|:-:|:-:|
 | `conclusionLevel` | Which check run conclusion type to use when annotations are created (`"neutral"` or `"failure"` are most common). See [GitHub Checks documentation](https://developer.github.com/v3/checks/runs/#parameters) for all available options.  | no | `"neutral"` |
+
+
+## Contributing
+
+### Local testing
+
+1. Setup [act](https://github.com/nektos/act) (`brew install act`)
+2. `yarn test` (Note: this will download a large (6-12gb) docker image that
+   matches what is ran on a GitHub action run)

--- a/action/action.rb
+++ b/action/action.rb
@@ -24,7 +24,7 @@ check_run = CheckRun.new(
 check_run_create = check_run.create(event: event)
 
 if !check_run_create.ok?
-  raise "Couldn't create check run #{resp.inspect}"
+  raise "Couldn't create check run #{check_run_create.inspect}"
 end
 
 compare_sha = event.pull_request.base.sha

--- a/action/action.rb
+++ b/action/action.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require "json"
-  require "ostruct"
+require "ostruct"
 
 require_relative "./install_gems"
 require_relative "./git_utils"
 require_relative "./check_run"
+
+if ENV["BALTO_LOCAL_TEST"]
+  require_relative "./fake_check_run"
+end
 
 CHECK_NAME = "Rubocop"
 
@@ -14,7 +18,9 @@ event = JSON.parse(
   object_class: OpenStruct
 )
 
-check_run = CheckRun.new(
+check_run_class = ENV["BALTO_LOCAL_TEST"] ? FakeCheckRun : CheckRun
+
+check_run = check_run_class.new(
   name: CHECK_NAME,
   owner: event.repository.owner.login,
   repo: event.repository.name,

--- a/action/fake_check_run.rb
+++ b/action/fake_check_run.rb
@@ -1,0 +1,25 @@
+require "ostruct"
+
+class FakeCheckRun
+  def initialize(name:, owner:, repo:, token:)
+    @name = name
+    @owner = owner
+    @repo = repo
+
+    puts "FAKE CHECK RUN: initialized with \n"
+    puts({ name: name, owner: owner, repo: repo }.to_yaml)
+  end
+
+  def create(event:)
+    puts "FAKE CHECK RUN: created with \n"
+    puts event.to_yaml
+
+    OpenStruct.new(ok?: true)
+  end
+
+  def update(annotations:)
+    puts "FAKE CHECK RUN: received annotations \n"
+    puts annotations.to_yaml
+    OpenStruct.new(json: annotations.to_json)
+  end
+end

--- a/local_test.env
+++ b/local_test.env
@@ -1,0 +1,1 @@
+BALTO_LOCAL_TEST=true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "act pull_request -e test/pull_request_event_payload.json --env-file local_test.env"
   },
   "author": "",
   "license": "ISC",

--- a/test/pull_request_event_payload.json
+++ b/test/pull_request_event_payload.json
@@ -1,0 +1,13 @@
+{
+  "pull_request": {
+    "base": {
+      "sha": "22b00741ec61ff185b06449115a9a448d4db00e9"
+    }
+  },
+  "repository": {
+    "owner": {
+      "login": "planningcenter"
+    },
+    "name": "balto-rubocop"
+  }
+}


### PR DESCRIPTION
A while back, I learned about [act][]: a tool that lets you run actions locally. By default act uses a very stripped down docker container that only runs node. That would be great for balto-eslint, but we need ruby for this action.

Act allows us to define an alternate docker image. Unfortunately, it's somewhere in the range of 6-12gb — but it has almost(?) everything that the regular github workflow action has.

Anyway, testing locally is definitely optional, but I wanted to get it up and running to get our feedback loop a bit smaller for some work I'm planning on in the future.

[act]: https://github.com/nektos/act