### PR TITLE
Handle Rubocop failures better

### DIFF
--- a/action/action.rb
+++ b/action/action.rb
@@ -58,6 +58,8 @@ def file_fullpath(relative_path)
 end
 
 def generate_annotations(compare_sha:)
+  raise "this is a fake error"
+
   annotations = []
 
   rubocop_json = Bundler.with_original_env do

--- a/action/action.rb
+++ b/action/action.rb
@@ -58,8 +58,6 @@ def file_fullpath(relative_path)
 end
 
 def generate_annotations(compare_sha:)
-  raise "this is a fake error"
-
   annotations = []
 
   rubocop_json = Bundler.with_original_env do

--- a/action/action.rb
+++ b/action/action.rb
@@ -96,7 +96,5 @@ rescue Exception => e
   p resp
   p resp.json
 else
-  resp = check_run.update(annotations: annotations)
-  p resp
-  p resp.json
+  check_run.update(annotations: annotations)
 end

--- a/action/action.rb
+++ b/action/action.rb
@@ -33,14 +33,6 @@ if !check_run_create.ok?
   raise "Couldn't create check run #{check_run_create.inspect}"
 end
 
-compare_sha = event.pull_request.base.sha
-
-rubocop_json = Bundler.with_original_env do
-  `git diff --name-only #{compare_sha} --diff-filter AM --relative | xargs rubocop --force-exclusion --format json`
-end
-
-rubocop_output = JSON.parse(rubocop_json, object_class: OpenStruct)
-
 RUBOCOP_TO_GITHUB_SEVERITY = {
   "refactor" => "failure",
   "convention" => "failure",
@@ -48,8 +40,6 @@ RUBOCOP_TO_GITHUB_SEVERITY = {
   "error" => "failure",
   "fatal" => "failure"
 }.freeze
-
-annotations = []
 
 def git_root
   @git_root ||= Pathname.new(GitUtils.root)
@@ -67,25 +57,46 @@ def file_fullpath(relative_path)
   end
 end
 
-rubocop_output.files.each do |file|
-  path = file_fullpath(file.path)
+def generate_annotations(compare_sha:)
+  annotations = []
 
-  change_ranges = GitUtils.generate_change_ranges(path, compare_sha: compare_sha)
-
-  file.offenses.each do |offense|
-    next unless change_ranges.any? { |range| range.include?(offense.location.start_line) }
-
-    annotations.push(
-      path: path,
-      start_line: offense.location.start_line,
-      end_line: offense.location.last_line,
-      annotation_level: RUBOCOP_TO_GITHUB_SEVERITY[offense.severity],
-      message: offense.message
-    )
+  rubocop_json = Bundler.with_original_env do
+    `git diff --name-only #{compare_sha} --diff-filter AM --relative | xargs rubocop --force-exclusion --format json`
   end
+
+  rubocop_output = JSON.parse(rubocop_json, object_class: OpenStruct)
+
+  rubocop_output.files.each do |file|
+    path = file_fullpath(file.path)
+
+    change_ranges = GitUtils.generate_change_ranges(path, compare_sha: compare_sha)
+
+    file.offenses.each do |offense|
+      next unless change_ranges.any? { |range| range.include?(offense.location.start_line) }
+
+      annotations.push(
+        path: path,
+        start_line: offense.location.start_line,
+        end_line: offense.location.last_line,
+        annotation_level: RUBOCOP_TO_GITHUB_SEVERITY[offense.severity],
+        message: offense.message
+      )
+    end
+  end
+
+  annotations
 end
 
-resp = check_run.update(annotations: annotations)
-
-p resp
-p resp.json
+begin
+  annotations = generate_annotations(compare_sha: event.pull_request.base.sha)
+rescue Exception => e
+  puts e.message
+  puts e.backtrace.inspect
+  resp = check_run.error(message: e.message)
+  p resp
+  p resp.json
+else
+  resp = check_run.update(annotations: annotations)
+  p resp
+  p resp.json
+end

--- a/action/check_run.rb
+++ b/action/check_run.rb
@@ -55,6 +55,23 @@ class CheckRun
     patch("/repos/#{owner}/#{repo}/check-runs/#{id}", body)
   end
 
+  def error(message:)
+    output = {
+      title: name,
+      summary: "Error during linting process",
+      text: message
+    }
+
+    body = {
+      status: "completed",
+      completed_at: Time.now.iso8601,
+      conclusion: "failure",
+      output: output,
+    }
+
+    patch("/repos/#{owner}/#{repo}/check-runs/#{id}", body)
+  end
+
   private
 
   attr_reader :owner, :repo, :headers, :id, :name

--- a/action/fake_check_run.rb
+++ b/action/fake_check_run.rb
@@ -22,4 +22,10 @@ class FakeCheckRun
     puts annotations.to_yaml
     OpenStruct.new(json: annotations.to_json)
   end
+
+  def error(message:)
+    puts "FAKE CHECK RUN: received error message \n"
+    puts message.to_yaml
+    OpenStruct.new(json: message.to_json)
+  end
 end


### PR DESCRIPTION
Previously, if a rubocop check raised an error, the action would exit but the check would not be updated as 'completed' — giving the appearance that action was still running.

In this PR, I wrapped most of the logic in a rescue block that will ensure updating the check in case of a failure.

Fixes #7 