### PR TITLE
Fix act not locating main.js

### DIFF
--- a/.github/workflows/balto.yml
+++ b/.github/workflows/balto.yml
@@ -7,15 +7,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout Locally
+        uses: actions/checkout@v2
+        with:
+          path: "balto-rubocop"
       - name: Read ruby version
-        run: echo ::set-output name=RUBY_VERSION::$(cat test/.ruby-version | cut -f 1,2 -d .)
+        run: echo ::set-output name=RUBY_VERSION::$(cat balto-rubocop/test/.ruby-version | cut -f 1,2 -d .)
         id: rv
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: "${{ steps.rv.outputs.RUBY_VERSION }}"
       - uses: ./
         with:
-          rootDirectory: test
+          rootDirectory: balto-rubocop/test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It was pretty painful trying to get `yarn test` to run. When running tests this happens:

```bash
[Balto/lint] ⭐  Run ./
| internal/modules/cjs/loader.js:985
|   throw err;
|   ^
|
| Error: Cannot find module '/github/workspace/balto-rubocop/main.js'
|     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:982:15)
|     at Function.Module._load (internal/modules/cjs/loader.js:864:27)
|     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
|     at internal/main/run_main_module.js:18:47 {
|   code: 'MODULE_NOT_FOUND',
|   requireStack: []
```

It seems like path resolution for node-based actions got changed in https://github.com/nektos/act/releases/tag/v0.2.16 and you should now provide a path to checkout

Related:

https://github.com/nektos/act/issues/228
https://github.com/nektos/act/pull/371
https://github.com/nektos/act/issues/185