### PR TITLE
feat: Add issuesCount output value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Make `push` events also work (https://github.com/planningcenter/balto-rubocop/pull/10)
+- Add `issuesCount` output (https://github.com/planningcenter/balto-rubocop/pull/12)
 
 ## v0.6 (2020-10-02)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ jobs:
 |:-:|:-:|:-:|:-:|
 | `conclusionLevel` | Which check run conclusion type to use when annotations are created (`"neutral"` or `"failure"` are most common). See [GitHub Checks documentation](https://developer.github.com/v3/checks/runs/#parameters) for all available options.  | no | `"neutral"` |
 
+## Outputs
+
+| Name | Description |
+|:-:|:-:|
+| `issuesCount` | Number of Rubocop violations found |
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -15,3 +15,6 @@ inputs:
     description: Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)
     required: false
     default: "neutral"
+outputs:
+  issuesCount:
+    description: "Number of rubocop violations found"

--- a/action/action.rb
+++ b/action/action.rb
@@ -12,7 +12,7 @@ if ENV["BALTO_LOCAL_TEST"]
   require_relative "./fake_check_run"
 end
 
-CHECK_NAME = "Rubocop"
+CHECK_NAME = "RuboCop"
 
 event = JSON.parse(
   File.read(ENV["GITHUB_EVENT_PATH"]),

--- a/action/action.rb
+++ b/action/action.rb
@@ -4,6 +4,7 @@ require "json"
 require "ostruct"
 
 require_relative "./install_gems"
+require_relative "./action_utils"
 require_relative "./git_utils"
 require_relative "./check_run"
 
@@ -102,4 +103,5 @@ rescue Exception => e
   p resp.json
 else
   check_run.update(annotations: annotations)
+  ActionUtils.set_output("issuesCount", annotations.count)
 end

--- a/action/action_utils.rb
+++ b/action/action_utils.rb
@@ -1,0 +1,7 @@
+module ActionUtils
+  module_function
+
+  def set_output(key, value)
+    puts "::set-output name=#{key}::#{value}"
+  end
+end

--- a/action/check_run.rb
+++ b/action/check_run.rb
@@ -20,7 +20,7 @@ class CheckRun
   def create(event:)
     body = {
       name: name,
-      head_sha: ENV['GITHUB_SHA'],
+      head_sha: event.pull_request ? event.pull_request.head.sha : ENV['GITHUB_SHA'],
       status: "in_progress",
       started_at: Time.now.iso8601,
     }


### PR DESCRIPTION
### Background
I'm using this action in another workflow that runs an auto-formatting action. I'd like to be able to skip the auto-formatting action if this RuboCop action didn't find any issues in the changed files.

### Changes
While I only need a boolean output value, adding the number of issues/violations found seems potentially more useful while equally as easy to implement.

In this process I noticed that the RuboCop annotations weren't being properly added to PRs.  I traced it back to a change in #10 and fixed it here.