### PR TITLE
feat(Severity): always report for high severity offenses

### DIFF
--- a/.github/workflows/balto.yml
+++ b/.github/workflows/balto.yml
@@ -7,13 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Read ruby version
-        run: echo ::set-output name=RUBY_VERSION::$(cat test/.ruby-version | cut -f 1,2 -d .)
-        id: rv
-      - uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v2
         with:
-          ruby-version: "${{ steps.rv.outputs.RUBY_VERSION }}"
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
       - uses: ./
         with:
           rootDirectory: test

--- a/action/action.rb
+++ b/action/action.rb
@@ -35,12 +35,14 @@ if !check_run_create.ok?
 end
 
 RUBOCOP_TO_GITHUB_SEVERITY = {
-  "refactor" => "failure",
-  "convention" => "failure",
+  "refactor" => "warning",
+  "convention" => "warning",
   "warning" => "warning",
   "error" => "failure",
   "fatal" => "failure"
 }.freeze
+
+FAILURE_LEVEL_ANNOTATIONS = RUBOCOP_TO_GITHUB_SEVERITY.select { |_, v| v == "failure" }.keys
 
 def git_root
   @git_root ||= Pathname.new(GitUtils.root)
@@ -89,7 +91,8 @@ def generate_annotations(compare_sha:)
 end
 
 def report_offense?(offense, change_ranges:)
-  change_ranges.any? { |range| range.include?(offense.location.start_line) }
+  FAILURE_LEVEL_ANNOTATIONS.include?(offense.severity) ||
+    change_ranges.any? { |range| range.include?(offense.location.start_line) }
 end
 
 begin

--- a/action/action.rb
+++ b/action/action.rb
@@ -73,7 +73,7 @@ def generate_annotations(compare_sha:)
     change_ranges = GitUtils.generate_change_ranges(path, compare_sha: compare_sha)
 
     file.offenses.each do |offense|
-      next unless change_ranges.any? { |range| range.include?(offense.location.start_line) }
+      next unless report_offense?(offense, change_ranges: change_ranges)
 
       annotations.push(
         path: path,
@@ -86,6 +86,10 @@ def generate_annotations(compare_sha:)
   end
 
   annotations
+end
+
+def report_offense?(offense, change_ranges:)
+  change_ranges.any? { |range| range.include?(offense.location.start_line) }
 end
 
 begin

--- a/action/check_run.rb
+++ b/action/check_run.rb
@@ -35,6 +35,8 @@ class CheckRun
   def update(annotations:)
     conclusion = if annotations.length.zero?
                    "success"
+                 elsif annotations.any? { |a| a[:annotation_level] == "failure" }
+                   "failure"
                  else
                    ENV["INPUT_CONCLUSIONLEVEL"]
                  end

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,0 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.5
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+  Severity: error

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -3,4 +3,7 @@ AllCops:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+  Severity: convention
+
+Style/FrozenStringLiteralComment:
   Severity: error

--- a/test/code.rb
+++ b/test/code.rb
@@ -1,5 +1,5 @@
-puts 'at least one of these lines'
-puts "is guaranteed to upset rubocop"
+puts "at least one of these lines"
+puts 'is guaranteed to upset rubocop'
 
 and_if_not = { this: :really, :ought => :to_do_it }
 

--- a/test/code.rb
+++ b/test/code.rb
@@ -1,4 +1,6 @@
-puts "at least one of these lines"
+
+
+puts 'at least one of these lines'
 puts 'is guaranteed to upset rubocop'
 
 and_if_not = { this: :really, :ought => :to_do_it }


### PR DESCRIPTION
Rubocop supports a variety of offense severities, and I'd like Balto
to be smarter about them.

In this PR I propose a few changes.

1. Make `refactor` and `convention` offenses appear with the Github
   `warning` annotation style (⚠️) instead of failure style (❌)
2. If there are any `failure` level offenses in a file, annotate them
   even if they are outside the change range. This raises the profile
   of these high-severity offenses, and also ensures that if you were
   to _remove_ code that caused a high-severity offense, it would
   still be reported.
3. If there are any `failure` level annotations, consider the check
   run a failure, loudly communicating the importance of the offense

These changes would particularly help out Giving, as we're actively
working on adding custom cops to our project, and we'd like to make
these cops `fatal` severity, communicating to ourselves that they're
rules we never want to break.

Taken together, I think these would constitute a major version change
for Balto, with the addition of new behaviors, and the new possibility
that you might set an `INPUT_CONCLUSIONLEVEL` and yet still have it
come back as a `failure` if you're using higher severity levels.

FWIW, best as I can tell, the only Rubocop cop that _by default_ has a
higher severity level than `warning` is the syntax error cop. So in
real world usage, I don't expect this to be a big change for users,
unless they've specifically set high severity for certain rules.

You can see an example of what this might look like in #15, where the check run is a failure, and we report an offense generated by a removed line