### PR TITLE
Add option to install all gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ jobs:
 
 | Name | Description | Required | Default |
 |:-:|:-:|:-:|:-:|
+| `rootDirectory` | The root directory to use for running the action  | no | `"."` |
 | `conclusionLevel` | Which check run conclusion type to use when annotations are created (`"neutral"` or `"failure"` are most common). See [GitHub Checks documentation](https://developer.github.com/v3/checks/runs/#parameters) for all available options.  | no | `"neutral"` |
+| `smartGemInstall` | Whether to try and install the fewest gems required to run RuboCop. When `"false"` it will run a full `bundle install`. | no | `"true"` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Which check run conclusion type to use when annotations are created ("neutral" or "failure" are most common)
     required: false
     default: "neutral"
+  smartGemInstall:
+    description: Whether to try and install the fewest gems required to run RuboCop. When "false" it will run a full `bundle install`.
+    required: false
+    default: "true"
 outputs:
   issuesCount:
     description: "Number of rubocop violations found"

--- a/action/action.rb
+++ b/action/action.rb
@@ -63,8 +63,10 @@ end
 def generate_annotations(compare_sha:)
   annotations = []
 
+  rubocop_cmd = ENV['INPUT_SMARTGEMINSTALL'].to_s.downcase == 'false' ? 'bundle exec rubocop' : 'rubocop'
+
   rubocop_json = Bundler.with_original_env do
-    `git diff --name-only #{compare_sha} --diff-filter AM --relative | xargs rubocop --force-exclusion --format json`
+    `git diff --name-only #{compare_sha} --diff-filter AM --relative | xargs #{rubocop_cmd} --force-exclusion --format json`
   end
 
   rubocop_output = JSON.parse(rubocop_json, object_class: OpenStruct)

--- a/action/install_gems.rb
+++ b/action/install_gems.rb
@@ -62,8 +62,19 @@ def gem_we_care_about?(name)
   name == 'standard' || name&.start_with?('rubocop')
 end
 
+class AllTheGemsStrategy
+  def install
+    require "bundler"
+    require "bundler/cli"
+
+    Bundler::CLI.start(['install'])
+  end
+end
+
 def choose_gem_strategy
-  if File.exist?('Gemfile.lock')
+  if ENV['INPUT_SMARTGEMINSTALL'].to_s.downcase == 'false'
+    AllTheGemsStrategy.new
+  elsif File.exist?('Gemfile.lock')
     GemfileStrategy.new
   elsif gemspec_file = Dir.glob('*.gemspec').first
     GemspecStrategy.new(gemspec_file)


### PR DESCRIPTION
### Issue
For large apps that have a bunch of dependencies, installing the fewest gems required to run RuboCop can provide quite the time savings. For smaller projects like gems, it's not as big of a deal. And especially in the case of a gem that integrates with RuboCop, getting everything installed just right is challenging.

### Solution
In lieu of adding more smarts to the existing gem install strategies, I opted for an escape hatch option that lets a user say they're fine with the full bundle install. In this case, we'll also run `rubocop` with `bundle exec` to make sure it's got access to everything in the bundle that it just installed.

### Other possibilities
The 2 big hurdles were having the ability to install other gems (in this case, one that's not public) and the need to use `bundle exec rubocop`.  I could see a future updates in which we can pass a list of additional gems to install, including a local gem.  But for now that felt like overkill.