### PR TITLE
Update readme, including permissions information

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write # may not be necessary, see note below
+    permissions: # may not be necessary, see note below
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,9 +45,9 @@ jobs:
 
 ## A note about permissions
 
-In the sample config above, we explicitly give `write` permissons to the [checks API](https://docs.github.com/en/rest/checks/runs) for the job that includes balto-rubocop as a step. Because balto-rubocop uses [check runs](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api), the `GITHUB_TOKEN` used in an action must have permissions to create a `check run`. 
+Because some tools, like [dependabot](https://github.com/dependabot), use tokens for actions that have read-only permissions, you'll need to elevate its permissions for this action to work with those sorts of tools. If you don't use any of those tools, and your workflow will only run when users with permissions in your repo create and update pull requests, you may not need these explicit permissions at all.
 
-Because some tools, like [dependabot](https://github.com/dependabot), have read-only permissions by default, you'll need to elevate its permissions for this to work with those sorts of tools. If you don't use any of those tools and your workflow will only run when users with permissions in the repo create and update pull requests, you may not need these explicit permissions at all.
+When defining any permissions in a workflow or job, you need to explicitly include any permission the action needs. In the sample config above, we explicitly give `write` permissons to the [checks API](https://docs.github.com/en/rest/checks/runs) for the job that includes balto-rubocop as a step. Because balto-rubocop uses [check runs](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api), the `GITHUB_TOKEN` used in an action must have permissions to create a `check run`. You'll also need `contents: read` for `actions/checkout` to be able to clone the code.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Balto is Smart and Fast:
 
-* Installs _your_ version of ruby
 * Installs _your_ versions of rubocop and rubocop extension gems
 * _Only_ runs on files that have changed
 * _Only_ annotates lines that have changed
@@ -20,14 +19,11 @@ jobs:
     permissions:
       checks: write # may not be necessary, see note below
     steps:
-      - uses: actions/checkout@v1
-      - name: Read ruby version
-        run: echo ::set-output name=RUBY_VERSION::$(cat .ruby-version | cut -f 1,2 -d .)
-        id: rv
-      - uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v3
         with:
-          ruby-version: "${{ steps.rv.outputs.RUBY_VERSION }}"
-      - uses: planningcenter/balto-rubocop@v0.6
+          fetch-depth: 0
+      - uses: actions/setup-ruby@v1
+      - uses: planningcenter/balto-rubocop@v0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-
+    permissions:
+      checks: write # may not be necessary, see note below
     steps:
       - uses: actions/checkout@v1
       - name: Read ruby version
@@ -44,6 +45,12 @@ jobs:
 | Name | Description |
 |:-:|:-:|
 | `issuesCount` | Number of Rubocop violations found |
+
+## A note about permissions
+
+In the sample config above, we explicitly give `write` permissons to the [checks API](https://docs.github.com/en/rest/checks/runs) for the job that includes balto-rubocop as a step. Because balto-rubocop uses [check runs](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api), the `GITHUB_TOKEN` used in an action must have permissions to create a `check run`. 
+
+Because some tools, like [dependabot](https://github.com/dependabot), have read-only permissions by default, you'll need to elevate its permissions for this to work with those sorts of tools. If you don't use any of those tools and your workflow will only run when users with permissions in the repo create and update pull requests, you may not need these explicit permissions at all.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
       - uses: planningcenter/balto-rubocop@v0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Issue

Some tools that trigger GitHub Actions have read-only permissions, which prevents balto-rubocop from creating its check run. These have been failing somewhat silently because we don't catch all errors and translate them to failures for the balto-rubocop step.  That's been addressed in #19.

### Fix
GitHub provides a way to elevate select permissions for a job. Let's add information about how to do that in the sample config and in longer form in the readme.

I also made a few smaller updates to the sample config to bring everything up-to-date.