### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.0 (2022-09-13)
+
 - **New**: install arbitrary gems through the `additionalGems` input (https://github.com/planningcenter/balto-rubocop/pull/19)
 - **New**: support more project setups with new minimal Gemfile strategy (https://github.com/planningcenter/balto-rubocop/pull/19)
 - **Breaking**: stop installing `standard` gem (when present) by default. Use `additionalGems` input instead (https://github.com/planningcenter/balto-rubocop/pull/19)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
-      - uses: planningcenter/balto-rubocop@v0.8
+      - uses: planningcenter/balto-rubocop@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### Strategy from here

The plan here is to rebase this onto `master` and create tags for `v1` and `v1.0.0` for this commit.  When subsequent `v1.x.x` releases are pushed, we'll update the `v1` tag to reference the latest `v1.x.x` tag, allowing people using the `v1` tag in their workflows to essentially get auto updates.  

This means we'll have to think about semantic versioning a bit more than we've had to in the past, making sure we don't break things with minor or patch releases.  We could also add a `v1.0` tag, but that feels like overkill and isn't something I see often in other actions which do use the `v1` style tags.