### PR TITLE
fix(CreateMinimalGemfile): Support more bundler versions

### DIFF
--- a/action/create_minimal_gemfile.rb
+++ b/action/create_minimal_gemfile.rb
@@ -38,7 +38,7 @@ class MinimalGemfile
         ref: source.options.fetch("revision")
       }
     when Bundler::Source::Rubygems
-      if source.multiple_remotes?
+      if source.remotes.size > 1
         fail "uncharted territory: gem source with multiple remotes #{remotes.inspect}"
       end
 


### PR DESCRIPTION
The `Bundler::Source::Rubygems#multiple_remotes?` method was added in bundler v2.3.0. It's implementation is simple enough that we can use it, which will prevent issues with bundler versions prior to v2.3.0.