### PR TITLE
fix: Improve error logging for push events without a before sha (like tag pushes)

### DIFF
--- a/action/action.rb
+++ b/action/action.rb
@@ -102,12 +102,16 @@ begin
                    event.pull_request.base.sha
                  end
   ActionUtils.debug "Using this as previous sha: #{previous_sha}"
-  annotations = if previous_sha == '0000000000000000000000000000000000000000'
-                  ActionUtils.debug "Skipping check run since we don't have a valid sha to compare"
-                  []
-                else
-                  generate_annotations(compare_sha: previous_sha)
-                end
+  annotations = []
+  if previous_sha.chars.uniq == ["0"]
+    error_msg = "#{previous_sha} is not a sha we can compare to -- aborting action run."
+    # Make sure this gets logged
+    puts error_msg
+    # ...because this output might not be captured
+    abort error_msg
+  else
+    annotations = generate_annotations(compare_sha: previous_sha)
+  end
 rescue Exception => e
   puts e.message
   puts e.backtrace.inspect

--- a/action/action.rb
+++ b/action/action.rb
@@ -101,6 +101,7 @@ begin
                  else
                    event.pull_request.base.sha
                  end
+  ActionUtils.debug "Using this as previous sha: #{previous_sha}"
   annotations = generate_annotations(compare_sha: previous_sha)
 rescue Exception => e
   puts e.message

--- a/action/action.rb
+++ b/action/action.rb
@@ -102,7 +102,12 @@ begin
                    event.pull_request.base.sha
                  end
   ActionUtils.debug "Using this as previous sha: #{previous_sha}"
-  annotations = generate_annotations(compare_sha: previous_sha)
+  annotations = if previous_sha == '0000000000000000000000000000000000000000'
+                  ActionUtils.debug "Skipping check run since we don't have a valid sha to compare"
+                  []
+                else
+                  generate_annotations(compare_sha: previous_sha)
+                end
 rescue Exception => e
   puts e.message
   puts e.backtrace.inspect

--- a/action/check_run.rb
+++ b/action/check_run.rb
@@ -3,6 +3,8 @@ require "net/http"
 require "json"
 require "ostruct"
 
+require_relative "./action_utils"
+
 class CheckRun
   def initialize(name:, owner:, repo:, token:)
     @name = name
@@ -18,9 +20,11 @@ class CheckRun
   end
 
   def create(event:)
+    head_sha = event.pull_request ? event.pull_request.head.sha : ENV['GITHUB_SHA']
+    ActionUtils.debug "Using this as head sha: #{head_sha}"
     body = {
       name: name,
-      head_sha: event.pull_request ? event.pull_request.head.sha : ENV['GITHUB_SHA'],
+      head_sha: head_sha,
       status: "in_progress",
       started_at: Time.now.iso8601,
     }


### PR DESCRIPTION
When a push event is sent for a tag, the `before` SHA is set to `0000000000000000000000000000000000000000` — which is not something we can run a diff against.

We were trying to pass it to rubocop, where it would silenty fail as `rubocop fatal: bad object 0000000000000000000000000000000000000000`

So let's just skip trying to run rubocop in those instances.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203239803057349