### PR TITLE
fix: Update deprecated output method

### DIFF
--- a/action/action_utils.rb
+++ b/action/action_utils.rb
@@ -2,7 +2,7 @@ module ActionUtils
   module_function
 
   def set_output(key, value)
-    puts "::set-output name=#{key}::#{value}"
+    `echo "#{key}=#{value}" >> $GITHUB_OUTPUT`
   end
 
   def debug(message)


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204035972885329
  - https://app.asana.com/0/0/1204035974663793