### PR TITLE
chore: Setup automated moving semantic version tags

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -1,0 +1,10 @@
+name: Release Tagger
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release-tagger:
+    uses: planningcenter/balto-utils/.github/workflows/release-tagger.yml@v1


### PR DESCRIPTION
We had a [long form discussion][1] about this last October and decided we wanted to eventually move all of our balto-* repos to use this release/tagging strategy.

Once this is merged in, I'll delete the v1 branch and make sure the workflow is ran for our existing code.

[1]: https://app.asana.com/0/0/1203245308278084