### PR TITLE
fix(source): fix for multiple source error error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+**Note:** changes since v1.0.1 can be found on the [releases page](https://github.com/planningcenter/balto-rubocop/releases)
 
 ## v1.0.1 (2022-10-19)
 

--- a/action/create_minimal_gemfile.rb
+++ b/action/create_minimal_gemfile.rb
@@ -39,7 +39,7 @@ class MinimalGemfile
       }
     when Bundler::Source::Rubygems
       if source.remotes.size > 1
-        fail "uncharted territory: gem source with multiple remotes #{remotes.inspect}"
+        fail "uncharted territory: gem source with multiple remotes #{source.remotes.inspect}"
       end
 
       if source.remotes.one? &&


### PR DESCRIPTION
With the push to start to move over to our internal Github Ruby gem service it seems like this failure will be more common. Happy to create an issue, or task to track it.

Also backfilled the changelog for the recent releases ✨ 

### Commit Message

A Gemfile in the repo-compliance-bot project has 2 remotes: rubygems, and our own Github ruby gem service for internal gems. It looks like `balto-rubocop` currently does not support that, but there was an error when generating the error.

This fixes the latter error error.

See [failing run](https://github.com/planningcenter/repo-compliance-bot/actions/runs/4961576178/jobs/8878528117?pr=33)
See [fixed run](https://github.com/planningcenter/repo-compliance-bot/actions/runs/4961867304/jobs/8879196519?pr=33) (still failing, but with the right message).